### PR TITLE
fix(*): Reduce extra digest loops when hide

### DIFF
--- a/angular.snackbar.js
+++ b/angular.snackbar.js
@@ -48,16 +48,15 @@
 				//add snackbar
 				angular.element(element).append(snackbar);
 
-				//snackbar duration timeout
+        //snackbar duration timeout
+				var $snackbar = angular.element(snackbar);
 				$timeout(function () {
 					//hide snackbar
-					return angular.element(snackbar).removeClass("snackbar-opened");
-
-				}, received.timeout || snackbarDuration).then(function (element) {
+					$snackbar.removeClass("snackbar-opened");
 
 					//remove snackbar
-					$timeout( function () { element.remove(); }, snackbarRemoveDelay);
-				});
+					$timeout( function () { $snackbar.remove(); }, snackbarRemoveDelay, false);
+        }, received.timeout || snackbarDuration, false);
 			
 			});
 		};


### PR DESCRIPTION
Earlier [PR](https://github.com/eu81273/angular.snackbar/commit/692dd6745690dd0184466eb79416e909b71b89a2) was failing because `$timeout` service does not return a promise if invokeApply parameter is false.

Demo: http://jsfiddle.net/wtfdzehr/6/
