### PR TITLE
Adding the ability to manually remove snackbars

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Forked from [eu81273/angular.snackbar.js](https://github.com/eu81273/angular.sna
 
 ## Example
 
-[jsFiddle - http://jsfiddle.net/eu81273/wtfdzehr/](http://jsfiddle.net/rockwotj/1h0rctcy/)
+[jsFiddle - http://jsfiddle.net/rockwotj/1h0rctcy/](http://jsfiddle.net/rockwotj/1h0rctcy/)
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Angular Snackbar
 Pure [AngularJS](http://www.angularjs.org) based Snackbar Component.
 (css based on https://github.com/FezVrasta/snackbarjs)
 
+Forked from [eu81273/angular.snackbar.js](https://github.com/eu81273/angular.snackbar)
 
 ## Example
 
-[jsFiddle - http://jsfiddle.net/eu81273/wtfdzehr/](http://jsfiddle.net/eu81273/wtfdzehr/)
+[jsFiddle - http://jsfiddle.net/eu81273/wtfdzehr/](http://jsfiddle.net/rockwotj/1h0rctcy/)
 
 
 
@@ -35,16 +36,9 @@ And add snackbar container tag to your application.
 
 This is all.
 
-some attributes of angular snackbar are below.
-
-- snackbar: snackbar directive.
-- snackbar-duration : snackbar duration time (ms).
-- snackbar-remove-delay : delay time to remove from DOM after hide (ms).
-
-
 ## Create snackbar
 
-Creating snackbar also very simple. Inject snackbar service to your app then call the service method like below.
+Creating a snackbar is also very simple. Inject snackbar service to your app then call the service method like below.
 
 
 ```javascript
@@ -52,21 +46,26 @@ var app = angular.module('angularApplication', ['angular.snackbar']);
 
 app.controller('defaultController', function($scope, snackbar) {
 
-	//create snackbar with default duration(3000ms)
-	snackbar.create("Hello World!!");
-	
-	//create snackbar with custom duration
-	snackbar.create("This is snackbar!!", 5000);
+	//create snackbar with an id of 1
+	snackbar.create("Hello World!!", 1);
 
+	//remove snackbar with id 1
+	snackbar.remove(1);
+
+	//create snackbar with a duration
+snackbar.createWithTimeout("Hello World!!");
 });
 
 ```
 
 ## Browser Compatibility
 
-Report me please. I just tested on Chrome 39.0.2171.95 m.
+Report me please. I just tested on Chrome.
 
 ## Changelogs
+
+#### version 1.1.0
+- Added the ability to manually toggle the snackbar
 
 #### version 1.0.1
 - Reduce extra digest loops when hide (Thanks to codef0rmer)
@@ -78,6 +77,6 @@ Report me please. I just tested on Chrome 39.0.2171.95 m.
 
 The MIT License.
 
-Copyright ⓒ 2015 AHN JAE-HA.
+Copyright ⓒ 2015 Tyler Rockwood.
 
-See [LICENSE](https://github.com/eu81273/angular.snackbar/blob/master/LICENSE)
+See [LICENSE](https://github.com/rockwotj/angular.snackbar/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ app.controller('defaultController', function($scope, snackbar) {
 	snackbar.remove(1);
 
 	//create snackbar with a duration
-snackbar.createWithTimeout("Hello World!!");
+	snackbar.createWithTimeout("Hello World!!");
 });
 
 ```

--- a/angular.snackbar.js
+++ b/angular.snackbar.js
@@ -1,67 +1,92 @@
 /*
 	@license Angular Snackbar version 1.0.1
-	ⓒ 2015 AHN JAE-HA http://github.com/eu81273/angular.snackbar
+	ⓒ 2015 Tyler Rockwood https://github.com/rockwotj/angular.snackbar
 	License: MIT
-
-	<div class="snackbar-container" data-snackbar="true" data-snackbar-duration="3000" data-snackbar-remove-delay="200"></div>
 */
 
-(function ( angular ) {
-	"use strict";
+/*
+@license Angular Snackbar version 1.0.1
+ⓒ 2015 Tyler Rockwood https://github.com/rockwotj/angular.snackbar
+License: MIT
 
-	var module = angular.module( "angular.snackbar", [] );
+<div class="snackbar-container" data-snackbar="true" data-snackbar-duration="3000" data-snackbar-remove-delay="200"></div>
+<!-- With custom delay -->
+<div class="snackbar-container" data-snackbar="true"></div>
+*/
 
-	//snackbar service
-	module.factory("snackbar", ['$rootScope', function ($rootScope) {
+(function (angular) {
+    "use strict";
 
-		return {
-			create : function ( content, duration ) { 
+    var module = angular.module("angular.snackbar", []);
 
-				$rootScope.$broadcast('createSnackbar', { 'content': content, 'duration': duration });
-			}
-		}
-	}]);
+    //snackbar service
+    module.factory("snackbar", ['$rootScope', function ($rootScope) {
+        return {
+            createWithTimeout: function (content, duration) {
 
-	//snackbar directive
-	module.directive( "snackbar", ["$rootScope", "$compile", "$timeout", function($rootScope, $compile, $timeout) {
+                $rootScope.$broadcast('createSnackbarWithTimeout', {
+                    'content': content,
+                        'duration': duration
+                });
+            },
+            create: function (content, id) {
+                $rootScope.$broadcast('createSnackbar', {
+                    'content': content,
+                        'id': id
+                });
+            },
+            remove: function (id) {
+                $rootScope.$broadcast('removeSnackbar', {
+                    'id': id
+                });
+            }
+        }
+    }]);
 
-		return function ( scope, element, attrs ) {
+    //snackbar directive
+    module.directive("snackbar", ["$rootScope", "$compile", "$timeout", function ($rootScope, $compile, $timeout) {
+        return function (scope, element, attrs) {
+            //snackbar container
+            var snackbarContainer = angular.element(element);
+            //snackbar duration time (ms)
+            var snackbarDuration = attrs.snackbarDuration || 3000;
+            //delay time to remove from DOM after hide (ms)
+            var snackbarRemoveDelay = attrs.snackbarRemoveDelay || 20;
+            //receive broadcating
+            $rootScope.$on('createSnackbarWithTimeout', function (event, received) {
+                //snackbar template
+                var template = "<div class=\"snackbar snackbar-opened\"><span class=\"snackbar-content\">" + received.content + "</span></div>";
+                //template compile
+                var snackbar = angular.element($compile(template)(scope));
+                //add snackbar
+                snackbarContainer.append(snackbar);
+                //snackbar duration time
+                $timeout(function () {
+                    //hide snackbar
+                    snackbar.removeClass("snackbar-opened");
+                    //remove snackbar
+                    $timeout(function () {
+                        snackbar.remove();
+                    }, snackbarRemoveDelay, false);
+                }, received.duration || snackbarDuration, false);
+            });
+            $rootScope.$on('createSnackbar', function (event, received) {
+                //snackbar template
+                var template = "<div class=\"snackbar snackbar-opened snackbar-id-" + received.id + "\"><span class=\"snackbar-content\">" + received.content + "</span></div>";
+                //template compile
+                var snackbar = angular.element($compile(template)(scope));
+                //add snackbar
+                snackbarContainer.append(snackbar);
 
-			//snackbar container
-			var snackbarContainer = angular.element(element);
-
-			//snackbar duration time (ms)
-			var snackbarDuration = attrs.snackbarDuration || 3000;
-
-			//delay time to remove from DOM after hide (ms)
-			var snackbarRemoveDelay = attrs.snackbarRemoveDelay || 200;
-
-
-			//receive broadcating
-			$rootScope.$on('createSnackbar', function(event, received) {
-
-				//snackbar template
-				var template = "<div class=\"snackbar snackbar-opened\"><span class=\"snackbar-content\">" + received.content + "</span></div>";
-
-				//template compile
-				var snackbar = angular.element($compile(template)(scope));
-
-				//add snackbar
-				snackbarContainer.append(snackbar);
-
-				//snackbar duration time
-				$timeout(function () {
-
-					//hide snackbar
-					snackbar.removeClass("snackbar-opened");
-
-					//remove snackbar
-					$timeout(function () { snackbar.remove(); }, snackbarRemoveDelay, false);
-
-				}, received.duration || snackbarDuration, false);
-
-			});
-		};
-	}]);
+            });
+            $rootScope.$on('removeSnackbar', function (event, received) {
+                var snackbar = angular.element(snackbarContainer[0].getElementsByClassName('snackbar-id-' + received.id));
+                //hide snackbar
+                snackbar.removeClass("snackbar-opened");
+                //remove snackbar
+                snackbar.remove();
+            });
+        };
+    }]);
 
 })(angular);

--- a/angular.snackbar.min.js
+++ b/angular.snackbar.min.js
@@ -1,8 +1,7 @@
 /*
 	@license Angular Snackbar version 1.0.1
-	ⓒ 2015 AHN JAE-HA http://github.com/eu81273/angular.snackbar
+	ⓒ 2015 Tyler Rockwood https://github.com/rockwotj/angular.snackbar
 	License: MIT
 */
 
-(function(a){var b=a.module("angular.snackbar",[]);b.factory("snackbar",["$rootScope",function(a){return{create:function(e,d){a.$broadcast("createSnackbar",{content:e,duration:d})}}}]);b.directive("snackbar",["$rootScope","$compile","$timeout",function(b,e,d){return function(g,h,c){var k=a.element(h),l=c.snackbarDuration||3E3,m=c.snackbarRemoveDelay||200;b.$on("createSnackbar",function(b,c){var f=a.element(e('<div class="snackbar snackbar-opened"><span class="snackbar-content">'+c.content+"</span></div>")(g));
-k.append(f);d(function(){f.removeClass("snackbar-opened");d(function(){f.remove()},m,!1)},c.duration||l,!1)})}}])})(angular);
+!function(a){"use strict";var n=a.module("angular.snackbar",[]);n.factory("snackbar",["$rootScope",function(a){return{createWithTimeout:function(n,e){a.$broadcast("createSnackbarWithTimeout",{content:n,duration:e})},create:function(n,e){a.$broadcast("createSnackbar",{content:n,id:e})},remove:function(n){a.$broadcast("removeSnackbar",{id:n})}}}]),n.directive("snackbar",["$rootScope","$compile","$timeout",function(n,e,c){return function(t,r,o){var s=a.element(r),i=o.snackbarDuration||3e3,u=o.snackbarRemoveDelay||20;n.$on("createSnackbarWithTimeout",function(n,r){var o='<div class="snackbar snackbar-opened"><span class="snackbar-content">'+r.content+"</span></div>",b=a.element(e(o)(t));s.append(b),c(function(){b.removeClass("snackbar-opened"),c(function(){b.remove()},u,!1)},r.duration||i,!1)}),n.$on("createSnackbar",function(n,c){var r='<div class="snackbar snackbar-opened snackbar-id-'+c.id+'"><span class="snackbar-content">'+c.content+"</span></div>",o=a.element(e(r)(t));s.append(o)}),n.$on("removeSnackbar",function(n,e){var c=a.element(s[0].getElementsByClassName("snackbar-id-"+e.id));c.removeClass("snackbar-opened"),c.remove()})}}])}(angular);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular.snackbar",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Pure AngularJS based Snackbar Component",
   "main": "angular.snackbar.js",
   "scripts": {
@@ -8,17 +8,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/eu81273/angular.snackbar.git"
+    "url": "https://github.com/rockwotj/angular.snackbar"
   },
   "keywords": [
     "angular.js",
     "AngularJS",
     "snackbar"
   ],
-  "author": "AHN JAE-HA",
+  "author": "Tyler Rockwood",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/eu81273/angular.snackbar/issues"
+    "url": "https://github.com/rockwotj/angular.snackbar/issues"
   },
-  "homepage": "https://github.com/eu81273/angular.snackbar"
+  "homepage": "https://github.com/rockwotj/angular.snackbar"
 }


### PR DESCRIPTION
Sometimes instead of briefly showing a snackbar, I want to be able to show it until some callback is called or a promise is resolved. So I added the functionality to create a snackbar with a id, then you are able to hide that by referencing the same id. I still kept the timeout feature, but added on this use-case.
